### PR TITLE
cleanup and make copy_payload idempotent

### DIFF
--- a/src/bin/rpm-info.rs
+++ b/src/bin/rpm-info.rs
@@ -7,10 +7,6 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "rpm-info")]
 struct Args {
-    /// Outputs results in JSON form
-    #[structopt(long = "json")]
-    json: bool,
-
     /// Path to data file
     #[structopt(name = "path", parse(from_os_str))]
     path: PathBuf,
@@ -23,6 +19,7 @@ struct Args {
 fn run(args: Args) -> Result<(), io::Error> {
     let file = RPMFile::open(args.path)?;
     let info: RPMInfo = (&file).into();
+
     if args.debug {
         println!("{:?}", file.lead);
         println!("{:?}", file.signature);


### PR DESCRIPTION
* remove json argument from rpm-info
* rename `write_payload` to `copy_payload`
* mimic `copy_payload` output to `io::copy`
* make `copy_payload` idempotent by adding start point `payload_offset` of payload to `RPMFile` and explicitly use it as a start position.